### PR TITLE
Allow customization of signs colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ let g:validator_filetype_map = {'<alias>': '<filetype_supported>'}
 let g:validator_filetype_map = {"python.django": "python"}
 ```
 
+To customize the signs colors, you can use the following groups:
+
+```vim
+" For syntax errors & warnings
+ValidatorErrorSign
+ValidatorWarningSign
+
+" For style errors & warnings
+" (By default, use the same colors as the 2 groups above)
+ValidatorStyleErrorSign
+ValidatorStyleWarningSign
+```
+
+
 Install
 -------
 

--- a/autoload/validator.vim
+++ b/autoload/validator.vim
@@ -134,10 +134,10 @@ endfunction
 
 
 function! s:highlight()
-  hi! ValidatorErrorSign ctermfg=88 ctermbg=235
-  hi! ValidatorWarningSign ctermfg=3 ctermbg=235
-  hi! link ValidatorStyleErrorSign ValidatorErrorSign
-  hi! link ValidatorStyleWarningSign ValidatorWarningSign
+  hi default ValidatorErrorSign ctermfg=88 ctermbg=235
+  hi default ValidatorWarningSign ctermfg=3 ctermbg=235
+  hi default link ValidatorStyleErrorSign ValidatorErrorSign
+  hi default link ValidatorStyleWarningSign ValidatorWarningSign
 
   call s:define_sign('Error', g:validator_error_symbol)
   call s:define_sign('Warning', g:validator_warning_symbol)


### PR DESCRIPTION
Add `default` keyword to allow redefining the colors of validator groups, and update the README accordingly.