### PR TITLE
php linter

### DIFF
--- a/pythonx/lints/php.py
+++ b/pythonx/lints/php.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from validator import Validator
+
+
+class Php(Validator):
+    __filetype__ = "php"
+
+    checker = "php"
+    args = "-l"
+    regex = r"""
+            .+:
+            \s
+            (?P<error>[\w\s]+),
+            \s
+            (?P<text>.*)
+            \s
+            in
+            .*
+            line\s(?P<lnum>\d+)"""


### PR DESCRIPTION
DISCLAIMER: I'm not a python developer, and I've never wrote python code before

I'm just a web developer who really likes this plugin. I've tried to add the support for the php build-in linter (`php -l file.php`).

I've created a class `Php` looking at the other linter. Unfortunately, when I open php files in vim (even with obvious syntax error) and nothings happens.

I've tested the regexp online at pythex.org and it seems to work.

```php
// test.php
<?php

echo "GHJK" // missing semicolon

echo $FFFF;

if ($test) {
    echo "YAY" // missing semicolon
    // "php -l file.php" return only the first error found
}
```

Example of output:
```
$ php -l test.php
PHP Parse error:  syntax error, unexpected 'echo' (T_ECHO), expecting ',' or ';' in test.php on line 5

Parse error: syntax error, unexpected 'echo' (T_ECHO), expecting ',' or ';' in test.php on line 5

Errors parsing test.php
```

example of the output at pythex.org

 - **Match 1**
    * lnum: 5
    * text: unexpected 'echo' (T_ECHO), expecting ',' or ';'
    * error: syntax error

 - **Match 2**
    * lnum: 5
    * text: unexpected 'echo' (T_ECHO), expecting ',' or ';'
    * error: syntax error

What could be done to make this works?