### PR TITLE
Fix rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,13 @@ let g:validator_<binary_name>_binary = '/path/to/executable'
 " For c/c++
 let g:validator_clang_tidy_binary = '/path/to/executable'
 
-" For example
+" For flake8
 let g:validator_python_flake8_args = '--max-line-length=120'
 let g:validator_python_flake8_binary = '/Users/maralla/.dotfiles/virtualenvs/py27/bin/flake8'
+
+" For rubocop
+let g:validator_ruby_rubocop_args = '-f s -c .rubocop.yml'
+let g:validator_ruby_rubocop_binary = '/Users/maralla/.rvm/gems/ruby-2.3.0/bin/rubocop'
 ```
 
 Install
@@ -126,3 +130,17 @@ Validator.vim automatically checks syntax in the background when file content
 changes, so no need to do any trigger manually. If you do want to do a check
 manually use this command `ValidatorCheck`. This command is especially useful
 when you set the file type manually.
+
+Debugging
+-----
+
+Enable the debugging with:
+
+```vim
+let g:validator_debug = 1
+```
+
+The output is logged in plugin installation directory:
+
+e.g. 
+`~/.vim/bundle/validator.vim/pythonx/validator.log`

--- a/pythonx/lints/ruby/rubocop.py
+++ b/pythonx/lints/ruby/rubocop.py
@@ -7,17 +7,17 @@ class Rubocop(Validator):
     __filetype__ = 'ruby'
 
     checker = 'rubocop'
-    args = '-f s'
+    args = '-f s -c .rubocop.yml'
     regex = r"""
             (
                 (?P<error>E)
                 |
                 (?P<warning>(W|C))
             ):
-            \s
+            \s*
             (?P<lnum>\d+):
-            \s
+            \s*
             (?P<col>\d+):
-            \s
+            \s*
             (?P<text>.*)
             """

--- a/pythonx/validator/__init__.py
+++ b/pythonx/validator/__init__.py
@@ -97,6 +97,8 @@ class Validator(Base):
         return ft in self._registry
 
     def parse_loclist(self, loclist, bufnr):
+        logging.warn("parse input = {}".format([self, loclist, bufnr]))
+
         if self.checker not in self._regex_map:
             self._regex_map[self.checker] = re.compile(self.regex, re.VERBOSE)
 
@@ -114,6 +116,8 @@ class Validator(Base):
                 "text": "[{}]{}".format(self.checker, loc.get('text', ''))
             })
             lists.append(loc)
+
+        logging.warn("parsed lists = {}".format(lists))
         return json.dumps(lists)
 
     def format_cmd(self, fpath):

--- a/tests/test_rubocop.py
+++ b/tests/test_rubocop.py
@@ -32,7 +32,7 @@ def test_rubocop_warning():
     }]
 
 def test_rubocop_style():
-    msg = ['C: 1: 3: Extra empty line detected at class body end']
+    msg = [u'C:  1: 3: Extra empty line detected at class body end']
 
     res = Rubocop().parse_loclist(msg, 1)
     assert json.loads(res) == [{


### PR DESCRIPTION
### Reason
Validator.vim was not working with Rubocop 0.41.1 because the output has extra spaces.
```
C:   1: 3: Extra
```
vs
```
C: 1: 3: Extra
```

### Changes


1. Rubocop lint to parse arbitrary number of whitespaces
2. Rubocop lint to use local not global config
3. Added logging for `parse_loclist`
4. README 