### PR TITLE
Add support for coffeelint

### DIFF
--- a/pythonx/lints/coffee/__init__.py
+++ b/pythonx/lints/coffee/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from .coffeelint import CoffeeLint  # noqa

--- a/pythonx/lints/coffee/coffeelint.py
+++ b/pythonx/lints/coffee/coffeelint.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from validator import Validator
+
+
+class CoffeeLint(Validator):
+    __filetype__ = "coffee"
+
+    stdin = True
+    checker = "coffeelint"
+    args = " --stdin --reporter csv"
+    regex = r"""
+            .+?,
+            (?P<lnum>\d+),
+            (?P<col>\d*),
+            (
+                (?P<error>error)
+                |
+                (?P<warning>warn)
+            ),
+            (?P<text>.*)"""


### PR DESCRIPTION
I tried creating a lint file without using `stdin = True`, but it didn't seem to work without it. Not sure why.