### PR TITLE
Fix: add final newline in stdin mode

### DIFF
--- a/autoload/validator.vim
+++ b/autoload/validator.vim
@@ -69,7 +69,7 @@ endfunction
 function! s:send_buffer(job, lines)
   let ch = job_getchannel(a:job)
   if ch_status(ch) == 'open'
-    call ch_sendraw(ch, join(a:lines, "\n"))
+    call ch_sendraw(ch, join(a:lines, "\n") . "\n")
     call ch_close_in(ch)
   endif
 endfunction


### PR DESCRIPTION
My linter (eslint) is configured to warn if the final EOL is missing.

We could actually read vim flags (endofline, fixendofline), but usually linters only run on code (non-binary) files and these flags are only disabled for binary files by default. Should be sane to always add the EOL.

(I did not run any tests, just tried it with my running eslint setup.)