### PR TITLE
Correct command line of clang-tidy

### DIFF
--- a/pythonx/lints/cpp.py
+++ b/pythonx/lints/cpp.py
@@ -25,4 +25,4 @@ class Cpp(Validator):
 
     def cmd(self, fname):
         return "{} {} -- {}".format(
-            self.binary, fname, self.parse_arguments(self.args_file))
+            self.binary, self.parse_arguments(self.args_file), fname)


### PR DESCRIPTION
The command line should be `clang-tidy <options> -- filename`, not `clang-tidy filename -- <options>`.